### PR TITLE
Bug/SK-307 | ImportError: module 'stackn' has no attribute 'main'

### DIFF
--- a/stackn/__init__.py
+++ b/stackn/__init__.py
@@ -1,0 +1,6 @@
+from .create import create  # noqa: F401
+from .delete import delete  # noqa: F401
+from .get import get  # noqa: F401
+from .login import login  # noqa: F401
+from .main import main  # noqa: F401
+from .set import set  # noqa: F401


### PR DESCRIPTION
During code-check implementation (SK-289)  Flake8 complained about unused imports in init file, and was thus removed. These need to be added back for the console_script entrypoint. 